### PR TITLE
Feat/device endpoint management

### DIFF
--- a/notihub/notifiers/aws/notifier.py
+++ b/notihub/notifiers/aws/notifier.py
@@ -319,3 +319,66 @@ class AWSNotifier(BaseNotifier):
             TargetArn=device,
             Message=message,
         )
+
+    def create_device_endpoint(self,platform_application_arn: str,device_token: str,custom_user_data: str = "",**kwargs):
+        """
+        Creates a platform endpoint for the given device token.
+        Args:
+            platform_application_arn (str): The ARN of the platform application (e.g., APNS).
+            device_token (str): The token associated with the device to register.
+            custom_user_data (str, optional): The custom user data to associate with the device endpoint.
+                This should be a JSON-formatted string representing user-specific data, such as user ID,
+                subscription type, etc. If not provided, no custom user data is associated with the endpoint.
+                Defaults to "".
+        Returns:
+            dict: Response from the SNS client operation, which includes the platform endpoint details
+                or an error message if the operation fails.
+        """
+        try:
+
+            response = self.sns_client.create_platform_endpoint(
+                PlatformApplicationArn=platform_application_arn,
+                Token=device_token,
+                CustomUserData=custom_user_data,
+            )
+
+            return response
+        except Exception as e:
+            return {str(e)}
+
+    def delete_device_endpoint(self, endpoint_arn: str, **kwargs) -> dict:
+        """
+        Deletes the platform endpoint for the given endpoint ARN.
+        Args:
+            endpoint_arn (str): The ARN of the platform endpoint to delete.
+        Returns:
+            dict: Response from the SNS client operation, which includes the result of the delete operation
+                or an error message if the operation fails.
+        """
+        try:
+            response = self.sns_client.delete_endpoint(EndpointArn=endpoint_arn)
+            return response
+        except Exception as e:
+            return {str(e)}
+
+    def update_device_endpoint(
+        self, endpoint_arn: str, custom_user_data: str = "", **kwargs
+    ) -> dict:
+        """
+        Updates the CustomUserData for the given platform endpoint.
+        Args:
+            endpoint_arn (str): The ARN of the platform endpoint to update.
+            custom_user_data (str): The new custom user data to associate with the endpoint.
+                This should be a JSON-formatted string representing user-specific data.
+        Returns:
+            dict: Response from the SNS client operation, which includes the updated platform endpoint details
+                or an error message if the operation fails.
+        """
+        try:
+
+            response = self.sns_client.set_endpoint_attributes(
+                EndpointArn=endpoint_arn, Attributes={"CustomUserData": custom_user_data}
+            )
+            return response
+        except Exception as e:
+            return {str(e)}

--- a/tests/aws_notifier_test.py
+++ b/tests/aws_notifier_test.py
@@ -211,7 +211,7 @@ class TestAWSNotifier(TestCase):
         response = self.aws_notifier.update_device_endpoint(
             self.endpoint_arn, self.custom_user_data
         )
-        print(response)
+     
         self.assertEqual(response["ResponseMetadata"]["HTTPStatusCode"], 200)
 
     def test_create_device_endpoint_success(self):

--- a/tests/aws_notifier_test.py
+++ b/tests/aws_notifier_test.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -116,8 +117,9 @@ class TestAWSNotifier(TestCase):
 
     def test_send_email_notification_with_subject_changes_template_subject(self):
         """Test send_email_notification"""
+        random_template_name = f"test-notihub-{uuid.uuid4()}"
         self.aws_notifier.create_email_template(
-            template_name="test-notihub",
+            template_name=random_template_name,
             subject="Test subject",
             text_body="Test text body",
             html_body="Test html body",
@@ -132,7 +134,7 @@ class TestAWSNotifier(TestCase):
         updated_template = self.aws_notifier.get_email_template(
             template_name="test-notihub"
         )
-        self.aws_notifier.delete_email_template(template_name="test-notihub")
+        self.aws_notifier.delete_email_template(template_name=random_template_name)
         self.assertEqual(updated_template["Template"]["SubjectPart"], "New subject")
 
     def test_send_push_notification_sends_push_notification(self):

--- a/tests/aws_notifier_test.py
+++ b/tests/aws_notifier_test.py
@@ -34,8 +34,8 @@ class TestAWSNotifier(TestCase):
             region_name="us-east-2",
         )
 
-        self.platform_application_arn = os.environ.get("DEVICE_ARN")
-        self.endpoint_arn = os.environ.get("AWS_SECRET_KEY")
+        self.platform_application_arn = os.environ.get("PLATFORM_APPLICATION_ARN")
+        self.endpoint_arn = os.environ.get("DEVICE_ARN")
         self.custom_user_data = '{"user_data": "test_data"}'
 
     def tearDown(self) -> None:
@@ -211,7 +211,7 @@ class TestAWSNotifier(TestCase):
         response = self.aws_notifier.update_device_endpoint(
             self.endpoint_arn, self.custom_user_data
         )
-
+        print(response)
         self.assertEqual(response["ResponseMetadata"]["HTTPStatusCode"], 200)
 
     def test_create_device_endpoint_success(self):

--- a/tests/aws_notifier_test.py
+++ b/tests/aws_notifier_test.py
@@ -14,7 +14,7 @@ class TestAWSNotifier(TestCase):
 
     def setUp(self):
         """Set up"""
-        load_dotenv("../.env")
+        load_dotenv(".env")
         self.aws_notifier = AWSNotifier(
             aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
             aws_secret_access_key=os.environ.get("AWS_SECRET_KEY"),
@@ -34,7 +34,9 @@ class TestAWSNotifier(TestCase):
             region_name="us-east-2",
         )
 
-        self.plataform_application_arn = os.environ.get("PLATFORM_APPLICATION_ARN")
+        self.platform_application_arn = os.environ.get("PLATFORM_APPLICATION_ARN")
+        print(self.platform_application_arn)
+
     def tearDown(self) -> None:
         if getattr(self, "topic_arn", None):
             self.aws_notifier.delete_topic(self.topic_arn)
@@ -221,7 +223,7 @@ class TestAWSNotifier(TestCase):
         # Mock the boto3 client
         mock_boto_client.return_value = MagicMock()
         mock_boto_client.return_value.create_platform_endpoint.return_value = {
-            "EndpointArn": self.plataform_application_arn
+            "EndpointArn": self.platform_application_arn
         }
 
         device_token = "fake_device_token"

--- a/tests/aws_notifier_test.py
+++ b/tests/aws_notifier_test.py
@@ -35,7 +35,6 @@ class TestAWSNotifier(TestCase):
         )
 
         self.platform_application_arn = os.environ.get("PLATFORM_APPLICATION_ARN")
-        print(self.platform_application_arn)
 
     def tearDown(self) -> None:
         if getattr(self, "topic_arn", None):

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -12,7 +12,7 @@ class TestNotifierClient(TestCase):
 
     def setUp(self):
         """Set up"""
-        load_dotenv("../.env")
+        load_dotenv(".env")
 
     def test_get_aws_notifier_returns_aws_notifier(self):
         """Test get_aws_notifier"""


### PR DESCRIPTION

## 🎯 Milestone 

Create, delete, and update platform endpoints for devices using SNS

### 🛠 Changes

- Implemented create_device_endpoint method: Added functionality to create platform endpoints for devices using their device tokens, allowing custom user data to be included if needed.

- Implemented delete_device_endpoint method: Implemented functionality to delete a device's platform endpoint given the endpoint ARN.

- Implemented update_device_endpoint method: Added the ability to update the custom user data associated with an existing device platform endpoint.

### 📘 Documentation 

- [ ] I have added or updated the documentation
- [x] No documentation update is required

### ✅ Unit test 
![image](https://github.com/user-attachments/assets/8a57e1e9-e610-4cb3-a4f9-0cda3d515cd7)